### PR TITLE
Tests should wait for PVC to be bound.

### DIFF
--- a/tests/src/common/kubeclient.py
+++ b/tests/src/common/kubeclient.py
@@ -99,6 +99,9 @@ class PersistentVolumeClaimAPI(KubeResourceAPI):
 
         return self.v1api.create_namespaced_persistent_volume_claim(self.namespace, body)
 
+    def get(self, name):
+        return self.v1api.read_namespaced_persistent_volume_claim(name, self.namespace)
+
     def delete(self, name):
         self.v1api.delete_namespaced_persistent_volume_claim(name, self.namespace, body=client.V1DeleteOptions())
 

--- a/tests/src/common/util.py
+++ b/tests/src/common/util.py
@@ -59,6 +59,17 @@ def create_pvc_for_pv(pv):
         "volumeName": pv.metadata.name
     }
 
-    return pvc_api.create(name, spec)
+    pvc = pvc_api.create(name, spec)
+
+    # Wait till PVC is bound
+    for i in range(30):
+        time.sleep(1)
+
+        pvc = pvc_api.get(name)
+        if pvc.status.phase == "Bound":
+            return pvc
+
+    raise Exception("PVC {} did not change to 'Bound' status.".format(name))
+
 
 


### PR DESCRIPTION
Otherwise, restore pod will not come up.