### PR TITLE
Skip assertion of restored files when running as part of CI.

### DIFF
--- a/tests/src/test_backup.py
+++ b/tests/src/test_backup.py
@@ -223,6 +223,12 @@ def test_restore(globalconfig, resources):
         restore_pod = globalconfig.pod_api.read(pod_name)
 
     assert restore_pod.status.phase == "Succeeded"
+
+    if os.environ.get("RUNNING_IN_CI", None):
+        print("Not verifying the contents of the target directory until we figure out how to check remote directories.")
+        return
+
+    print("Verifying the contents of the target directory...")
     assert os.path.exists("{}/data/etcd-snapshot.db".format(resources["pv_path"]))
     assert os.path.exists("{}/data/certificates".format(resources["pv_path"]))
     assert os.listdir(resources["pv_path"])


### PR DESCRIPTION
Restore test creates a HostPath type of PV and after restore is
complete, it verifies that etcd snapshot and certificate files are
indeed restored. This check is not working when the test runs in CI
environment because the Kubernetes cluster is remotely accessed.

Until we figure out how to check remote directories, the file assertion
is skipped for CI tests. Note that the test still verifies that restore
operation is marked as success.